### PR TITLE
fix UnboundLocalError when not self.url

### DIFF
--- a/save_to_zotero/save_to_zotero.py
+++ b/save_to_zotero/save_to_zotero.py
@@ -570,7 +570,7 @@ class SaveToZotero:
         temp_filename = f"{self.domain}_{int(time.time())}.pdf"
         pdf_path = pdf_dir / temp_filename
 
-		metadata = None
+        metadata = None
         if self.url:
             # Save the webpage as PDF
             metadata = save_webpage_as_pdf(self.url, str(pdf_path), self.wait, self.verbose)

--- a/save_to_zotero/save_to_zotero.py
+++ b/save_to_zotero/save_to_zotero.py
@@ -570,6 +570,7 @@ class SaveToZotero:
         temp_filename = f"{self.domain}_{int(time.time())}.pdf"
         pdf_path = pdf_dir / temp_filename
 
+		metadata = None
         if self.url:
             # Save the webpage as PDF
             metadata = save_webpage_as_pdf(self.url, str(pdf_path), self.wait, self.verbose)


### PR DESCRIPTION
fix UnboundLocalError: local variable 'metadata' referenced before assignment when not self.url